### PR TITLE
Rewrote url handling part using urlparse and urllib

### DIFF
--- a/clickanalysis/middleware/__init__.py
+++ b/clickanalysis/middleware/__init__.py
@@ -1,3 +1,6 @@
+from urlparse import parse_qsl, urlparse, urlunsplit
+from urllib import urlencode
+
 from clickanalysis.models import Campaign, ClickTracking
 from django.http import HttpResponseRedirect
 
@@ -10,32 +13,22 @@ class ClickAnalysisMiddleware(object):
     """
 
     def process_request(self, request):
+
         if request.GET.get('cid', ''):  # Will process the logic only if campaign id is present
             try:
                 campaign = Campaign.objects.get(campaign_id=request.GET['cid'])
-            except:
+            except Campaign.DoesNotExist:
                 campaign = None
 
             # Clearing the cid parameter from the link or providing a clean url for user to redirect
-            get_params = request.get_full_path().split('?')[1].split('&')
-            params_to_send = []
-            for g_p in get_params:
-                name = g_p.split('=')[0]
-                if name != 'cid':
-                    params_to_send.append(g_p)
+            url_parsed = urlparse(request.get_full_path())
+            get_params = parse_qsl(url_parsed.query)
+            params_to_send = urlencode([(k, v) for k, v in get_params if k != 'cid'])
+            url = urlunsplit(url_parsed[:3] + (params_to_send,) + url_parsed[5:])
 
-            params = '&'.join(params_to_send)
-            if params_to_send:
-                url = request.get_full_path().split('?')[0] + '?' + params
-            else:
-                url = request.get_full_path().split('?')[0]
-
-            if campaign:  # If campaign was found then here the click will be recorded
+            if campaign is not None:  # If campaign was found then here the click will be recorded
                 click, created = ClickTracking.objects.get_or_create(campaign=campaign, link=url)
-                if created:
-                    click.count = 1
-                else:
-                    click.count += 1
+                click.count += 1
                 click.save()
 
             return HttpResponseRedirect(url)


### PR DESCRIPTION
- Don't use [bare `except` clauses](https://docs.python.org/2/howto/doanddont.html#except).
- Instead of handling query parameters manually it's better to use modules from standard library:  [`urlparse`](https://docs.python.org/2/library/urlparse.html) and [`urllib`](https://docs.python.org/2/library/urllib.html).
- Lastly as the default value of [`ClickTracking.count`](https://github.com/nitishkansal/django-clickanalysis/blob/master/clickanalysis/models.py#L52) is 0 we can simply use +=1, i.e `if` condition is not required.
